### PR TITLE
Fix of optional ambiguity

### DIFF
--- a/components/wmbus_common/manufacturer_specificities.h
+++ b/components/wmbus_common/manufacturer_specificities.h
@@ -22,8 +22,6 @@
 #include"util.h"
 #include"wmbus.h"
 
-using namespace std;
-
 // Common: add default manufacturers key if none specified and we know one for the given frame
 void addDefaultManufacturerKeyIfAny(const vector<uchar> &frame, TPLSecurityMode tpl_sec_mode, MeterKeys *meter_keys);
 

--- a/components/wmbus_common/meters.h
+++ b/components/wmbus_common/meters.h
@@ -78,8 +78,10 @@ bool isMeterDriverReasonableForMedia(string driver_name, int media);
 struct MeterInfo;
 bool isValidKey(const string& key, MeterInfo &mt);
 
-using namespace std;
-
+template<typename T>
+using function = std::function<T>;
+template<typename T>
+using shared_ptr = std::shared_ptr<T>;
 
 struct MeterInfo
 {

--- a/components/wmbus_common/wmbus.h
+++ b/components/wmbus_common/wmbus.h
@@ -277,7 +277,10 @@ AFLAuthenticationType fromIntToAFLAuthenticationType(int i);
 const char *toString(AFLAuthenticationType aat);
 int toLen(AFLAuthenticationType aat);
 
-using namespace std;
+
+using string = std::string;
+template<typename T>
+using vector = std::vector<T>;
 
 struct MeterKeys
 {


### PR DESCRIPTION
`using namespace std` inside wmbusmeters headers