### PR TITLE
Add script to automate dependencies bumping

### DIFF
--- a/scripts/components_version.py
+++ b/scripts/components_version.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+import argparse
+from logging import getLogger
+
+from release_utils import (
+    COMMON_PARSER,
+    PARENT_DIR,
+    CommonArgs,
+    Tag,
+    checkout_master,
+    ensure_clean_tree,
+    git,
+    replace_versions_content,
+    setup_logging,
+)
+from urllib3 import request
+
+logger = getLogger(__name__)
+
+
+REPO = "IoTLabs-pl/ESPHome-components"
+YAML_KEY = "esphome_components_version"
+
+
+def get_current_version():
+    for line in (
+        PARENT_DIR.joinpath("packages", "version.yaml").read_text().splitlines()
+    ):
+        line = line.strip()
+        key, _, value = map(str.strip, line.partition(":"))
+        if key == YAML_KEY:
+            return Tag(value)
+
+    raise RuntimeError(
+        f"Could not find '{YAML_KEY}' in version.yaml. "
+        "Please ensure the file is formatted correctly."
+    )
+
+
+def latest_version():
+    logger.info("Fetching latest version from GitHub...")
+    resp = request("GET", f"https://api.github.com/repos/{REPO}/releases/latest")
+    if resp.status != 200:
+        raise RuntimeError(
+            f"Failed to fetch latest version: {resp.status} {getattr(resp, 'reason', '')}"
+        )
+    latest_version = Tag(resp.json()["tag_name"])
+    logger.debug("Got latest version: %s", latest_version)
+    return latest_version
+
+
+def parse_args():
+    class Args(CommonArgs):
+        version: Tag | None
+
+    parser = argparse.ArgumentParser(
+        description="Change external ESPHome components version.",
+        parents=[COMMON_PARSER],
+    )
+
+    parser.add_argument(
+        "--version",
+        help="Specify an explicit version (e.g., 1.2.3).",
+        type=Tag,
+    )
+
+    return parser.parse_args(namespace=Args())
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    setup_logging(args)
+
+    checkout_master(args.dry_run)
+    ensure_clean_tree(args.dry_run)
+
+    current_version = get_current_version()
+
+    if args.version:
+        new_version = args.version
+    else:
+        new_version = latest_version()
+
+    input(
+        f"Press Enter to continue with version {new_version} (or Ctrl+C to cancel)..."
+    )
+
+    logger.info("Creating branch for new version...")
+    git("checkout", "-b", f"components-{new_version}", dry_run=args.dry_run)
+
+    replace_versions_content(
+        current_version,
+        new_version,
+        {
+            PARENT_DIR / "packages" / "version.yaml": f"{YAML_KEY}: {{version}}",
+        },
+        dry_run=args.dry_run,
+    )
+
+    logger.info("Committing changes...")
+    git("commit", "-am", f"Bump {REPO} to {new_version}", dry_run=args.dry_run)
+
+    logger.info("Pushing changes...")
+    git("push", dry_run=args.dry_run)

--- a/scripts/pre_release.py
+++ b/scripts/pre_release.py
@@ -1,83 +1,37 @@
 #!/usr/bin/env python3
 
 import argparse
-import logging
-from pathlib import Path
+from logging import getLogger
 
-from esphome.git import run_git_command
-from semantic_version import Version
-import difflib
+from release_utils import (
+    COMMON_PARSER,
+    PARENT_DIR,
+    CommonArgs,
+    Tag,
+    checkout_master,
+    ensure_clean_tree,
+    git,
+    replace_versions_content,
+    setup_logging,
+)
 
-logger = logging.getLogger(__name__)
-
-
-TAG_PREFIX = "v"
-PARENT_DIR = Path(__file__).parent.parent.resolve()
-
-
-def git(*args, dry_run=True):
-    if dry_run:
-        logger.info(f"Would run: git {' '.join(args)}")
-        return ""
-    return run_git_command(["git", *args], cwd=PARENT_DIR)
+logger = getLogger(__name__)
 
 
 def get_latest_tag():
     output = git("describe", "--tags", "--abbrev=0", "--match", "v*", dry_run=False)
-    return Version(output.strip().removeprefix(TAG_PREFIX))
-
-
-def checkout_master(dry_run=True):
-    git("checkout", "master", dry_run=dry_run)
-
-
-def ensure_clean_tree(dry_run=True):
-    output = git("status", "--porcelain", dry_run=dry_run)
-
-    if output:
-        raise RuntimeError(
-            "Git tree is not clean. Please commit or stash your changes before tagging."
-        )
-
-
-def replace_versions_content(old_version: Version, new_version: Version, dry_run=True):
-    REPLACEMENTS = {
-        PARENT_DIR / "packages" / "version.yaml": "wmbus_gateway_version: {version}",
-        PARENT_DIR / "blueprint.yaml": "wmbus_gateway.yaml@{version}",
-    }
-    for file, replacement in REPLACEMENTS.items():
-        content = file.read_text()
-        new_content = content.replace(
-            replacement.format(version=f"{TAG_PREFIX}{old_version}"),
-            replacement.format(version=f"{TAG_PREFIX}{new_version}"),
-        )
-
-        if content != new_content:
-            diff = difflib.unified_diff(
-                content.splitlines(),
-                new_content.splitlines(),
-                lineterm="",
-            )
-            logger.info(
-                f"Updating {file.relative_to(PARENT_DIR)} from {old_version} to {new_version}"
-            )
-            for line in diff:
-                logger.debug(line)
-
-            if not dry_run:
-                file.write_text(new_content)
-        else:
-            raise RuntimeError(f"No changes made to {file}")
+    return Tag(output.strip())
 
 
 def parse_args():
-    class Args(argparse.Namespace):
-        bump: str | None
-        version: str | None
-        dry_run: bool
-        verbose: bool
+    class Args(CommonArgs):
+        bump: str | None = None
+        version: Tag | None = None
 
-    parser = argparse.ArgumentParser(description="Tag a new version.")
+    parser = argparse.ArgumentParser(
+        description="Tag a new version.",
+        parents=[COMMON_PARSER],
+    )
 
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
@@ -85,16 +39,10 @@ def parse_args():
         choices=["major", "minor", "patch"],
         help="Type of version bump (major, minor, patch).",
     )
-    group.add_argument("--version", help="Specify an explicit version (e.g., 1.2.3).")
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be done, but don't make any changes.",
-    )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Enable verbose (DEBUG) logging.",
+    group.add_argument(
+        "--version",
+        help="Specify an explicit version (e.g., 1.2.3).",
+        type=Tag,
     )
 
     return parser.parse_args(namespace=Args())
@@ -103,27 +51,36 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
 
-    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+    setup_logging(args)
 
     checkout_master(args.dry_run)
     ensure_clean_tree(args.dry_run)
 
-    last_version = get_latest_tag()
+    latest_tag = get_latest_tag()
 
     if args.version:
-        new_version = Version(args.version)
+        new_tag = args.version
     else:
-        new_version = getattr(last_version, f"next_{args.bump}")()
+        new_tag = Tag(str(getattr(latest_tag, f"next_{args.bump}")()))
 
-    input(
-        f"Press Enter to continue with version {new_version} (or Ctrl+C to cancel)..."
+    input(f"Press Enter to continue with version {new_tag} (or Ctrl+C to cancel)...")
+
+    replace_versions_content(
+        latest_tag,
+        new_tag,
+        {
+            PARENT_DIR
+            / "packages"
+            / "version.yaml": "wmbus_gateway_version: {version}",
+            PARENT_DIR / "blueprint.yaml": "wmbus_gateway.yaml@{version}",
+        },
+        dry_run=args.dry_run,
     )
-    replace_versions_content(last_version, new_version, args.dry_run)
 
     logger.info("Committing version update...")
-    git("commit", "-am", f'Release {new_version}', dry_run=args.dry_run)
+    git("commit", "-am", f"Release {new_tag}", dry_run=args.dry_run)
 
-    for tag in [f"{TAG_PREFIX}{new_version}", "latest"]:
+    for tag in [new_tag, "latest"]:
         logger.info(f"Tagging with: {tag}")
         git("tag", "--force", tag, dry_run=args.dry_run)
 

--- a/scripts/release_utils.py
+++ b/scripts/release_utils.py
@@ -1,0 +1,99 @@
+import argparse
+import difflib
+import logging
+from pathlib import Path
+
+from esphome.git import run_git_command
+from semantic_version import Version
+
+logger = logging.getLogger(__name__)
+
+
+PARENT_DIR = Path(__file__).parent.parent.resolve()
+
+
+COMMON_PARSER = argparse.ArgumentParser(add_help=False)
+COMMON_PARSER.add_argument(
+    "--dry-run",
+    action="store_true",
+    help="Show what would be done, but don't make any changes.",
+)
+COMMON_PARSER.add_argument(
+    "-v",
+    "--verbose",
+    action="store_true",
+    help="Enable verbose (DEBUG) logging.",
+)
+
+
+class CommonArgs(argparse.Namespace):
+    dry_run: bool
+    verbose: bool
+
+
+def setup_logging(args: CommonArgs):
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+    )
+
+
+class Tag(Version):
+    TAG_PREFIX = "v"
+
+    def __init__(self, string_version: str):
+        super().__init__(string_version.removeprefix(self.TAG_PREFIX))
+
+    def __str__(self):
+        return f"{self.TAG_PREFIX}{super().__str__()}"
+
+
+def git(*args, dry_run=True):
+    if dry_run:
+        logger.info(f"Would run: git {' '.join(map(str, args))}")
+        return ""
+    return run_git_command(["git", *args], cwd=PARENT_DIR)
+
+
+def checkout_master(dry_run=True):
+    git("checkout", "master", dry_run=dry_run)
+
+
+def ensure_clean_tree(dry_run=True):
+    output = git("status", "--porcelain", dry_run=dry_run)
+    if output and not dry_run:
+        raise RuntimeError(
+            "Git tree is not clean. Please commit or stash your changes before tagging."
+        )
+
+
+def replace_versions_content(
+    old_version: Tag,
+    new_version: Tag,
+    replacements: dict[Path, str],
+    dry_run=True,
+):
+    for file, replacement in replacements.items():
+        content = file.read_text()
+        new_content = content.replace(
+            replacement.format(version=old_version),
+            replacement.format(version=new_version),
+        )
+        if content != new_content:
+            diff = difflib.unified_diff(
+                content.splitlines(),
+                new_content.splitlines(),
+                lineterm="",
+            )
+            logger.info(
+                f"Updating {file.relative_to(PARENT_DIR)} from {old_version} to {new_version}"
+            )
+            for line in diff:
+                logger.debug(line)
+            if not dry_run:
+                file.write_text(new_content)
+        else:
+            raise RuntimeError(f"No changes made to {file}")
+
+
+def common_parser():
+    return COMMON_PARSER


### PR DESCRIPTION
Added a new script to manage the version of external ESPHome components. This script supports fetching the latest version from GitHub, creating a new branch, updating the version in configuration files, and committing and pushing changes.