### PR TITLE
Built-in LED behaviour customization

### DIFF
--- a/packages/heltec_lora32_v2_hal.yaml
+++ b/packages/heltec_lora32_v2_hal.yaml
@@ -5,6 +5,7 @@ esphome:
 esp32:
   board: heltec_wifi_lora_32_V2
   flash_size: 8MB
+  cpu_frequency: 240MHz
   framework:
     type: esp-idf
 
@@ -45,7 +46,7 @@ output:
 
 light:
   - platform: status_led
-    id: status_led_
+    id: wmbus_gateway_status_led
     pin: GPIO25
 
 binary_sensor:

--- a/packages/wmbus_gateway.yaml
+++ b/packages/wmbus_gateway.yaml
@@ -41,7 +41,7 @@ wmbus_radio:
             count: 20
             then:
               - light.control:
-                  id: status_led_
+                  id: wmbus_gateway_status_led
                   state: !lambda return iteration % 2 == 0;
               - delay: 50ms
 


### PR DESCRIPTION
* Expanded the `README.md` with detailed instructions on how to customize the built-in LED behavior for different use cases, including disabling the LED, changing the blink pattern, and configuring it for specific meter IDs.
* Increased the default CPU frequency to 240MHz for improved performance.
